### PR TITLE
✨ Heredar set_quantity en POS para aplicar lógica de descuentos perso…

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -31,6 +31,7 @@ Ideal para escenarios como "Compra 2, el segundo al 50%" o "Compra 4 y recibe 2 
     'assets': {
         'point_of_sale.assets': [
             'l10n_mx_quemen/static/src/js/productscreen_extension.js',
+            'l10n_mx_quemen/static/src/js/orderline_extension.js',
         ],
     },
 }

--- a/static/src/js/orderline_extension.js
+++ b/static/src/js/orderline_extension.js
@@ -1,0 +1,76 @@
+odoo.define('l10n_mx_quemen.OrderlineExtension', function(require) {
+    'use strict';
+
+    const models = require('point_of_sale.models');
+    const _orderline_super = models.Orderline.prototype;
+
+    models.Orderline = models.Orderline.extend({
+        set_quantity: function(quantity, keep_price) {
+            console.log("🔢 [l10n_mx_quemen] set_quantity", quantity);
+
+            const res = _orderline_super.set_quantity.apply(this, [quantity, keep_price]);
+
+            if (this.is_program_reward || quantity === 'remove') {
+                return res;
+            }
+
+            setTimeout(() => {
+                const order = this.order;
+                const product = this.product;
+
+                if (!order || !order.pos || !order.pos.promo_programs || !product) {
+                    return;
+                }
+
+                const rewardLines = order.get_orderlines().filter(line => line.is_program_reward);
+                if (!rewardLines.length) {
+                    console.log("⛔ No hay rewardLines, saliendo.");
+                    return;
+                }
+
+                const lastRewardLine = rewardLines[rewardLines.length - 1];
+                const program = order.pos.promo_programs.find(p => p.id === lastRewardLine.program_id);
+
+                if (
+                    !program ||
+                    !program.discount_logic ||
+                    program.reward_type !== 'discount' ||
+                    !program.rule_min_quantity
+                ) {
+                    console.log("⛔ Programa no válido o no aplica lógica de descuento.");
+                    return;
+                }
+
+                const validProductIds = new Set(program.valid_product_ids || []);
+
+                const validLines = order
+                    .get_orderlines()
+                    .filter(l => validProductIds.has(l.product.id) && !l.is_program_reward);
+
+                if (!validLines.length) {
+                    console.log("⛔ No hay productos válidos en el pedido. No se actualiza rewardLine.");
+                    return;
+                }
+
+                const appliedQty = validLines.reduce((sum, l) => sum + l.quantity, 0);
+                const minQty = program.rule_min_quantity;
+                const groups = Math.floor(appliedQty / minQty);
+                const allowedRewardQty = groups * (program.reward_product_quantity || 1);
+
+                if (allowedRewardQty >= 1) {
+                    const discountPerUnit = validLines[0].product.lst_price * (program.discount_percentage / 100);
+                    const newDiscountTotal = allowedRewardQty * discountPerUnit;
+                    lastRewardLine.set_unit_price(-newDiscountTotal);
+                    console.log(`✅ Precio ajustado: -${newDiscountTotal} por ${allowedRewardQty} unidad(es)`);
+                } else {
+                    lastRewardLine.set_unit_price(0);
+                    console.log("⛔ No se cumple la cantidad mínima, descuento eliminado");
+                }
+            }, 0); // 🔁 Esperamos al próximo ciclo de eventos
+
+            return res;
+        },
+    });
+
+    return models.Orderline;
+});

--- a/static/src/js/productscreen_extension.js
+++ b/static/src/js/productscreen_extension.js
@@ -7,44 +7,56 @@ odoo.define('l10n_mx_quemen.OrderExtension', function(require) {
     models.Order = models.Order.extend({
         add_product(product, options) {
             const res = _super_order.add_product.apply(this, arguments);
+            console.log("res ", res);
 
             const selectedProduct = this.get_selected_orderline()?.product;
+            console.log("selectedProduct ", selectedProduct);
 
             if (this.pos.promo_programs && selectedProduct) {
                 setTimeout(() => {
                     const rewardLines = this.get_orderlines().filter(line => line.is_program_reward);
+                    console.log("rewardLines ", rewardLines);
 
-                    if (rewardLines.length) {
-                        const lastRewardLine = rewardLines[rewardLines.length - 1];
-                        const program = this.pos.promo_programs.find(p => p.id === lastRewardLine.program_id);
+                    if (!rewardLines.length) {
+                        return;
+                    }
 
-                        if (
-                            program &&
-                            program.discount_logic &&  // ✅ verificamos el nuevo campo
-                            program.reward_type === 'discount' &&
-                            program.rule_min_quantity
-                        ) {
-                            const appliedQty = this
-                                .get_orderlines()
-                                .filter(l => l.product.id === selectedProduct.id && !l.is_program_reward)
-                                .reduce((sum, l) => sum + l.quantity, 0);
+                    const lastRewardLine = rewardLines[rewardLines.length - 1];
+                    const program = this.pos.promo_programs.find(p => p.id === lastRewardLine.program_id);
 
-                            const minQty = program.rule_min_quantity;
-                            const groups = Math.floor(appliedQty / minQty);
-                            const allowedRewardQty = groups * (program.reward_product_quantity || 1);
+                    if (
+                        program &&
+                        program.discount_logic &&
+                        program.reward_type === 'discount' &&
+                        program.rule_min_quantity
+                    ) {
+                        // 👉 Aquí verificamos si hay líneas válidas del producto de la promoción
+                        const validLines = this
+                            .get_orderlines()
+                            .filter(l => program.valid_product_ids.has(l.product.id) && !l.is_program_reward);
 
-                            if (allowedRewardQty >= 1) {
-                                const discountPerUnit = selectedProduct.lst_price * (program.discount_percentage / 100);
-                                const newDiscountTotal = allowedRewardQty * discountPerUnit;
-                                lastRewardLine.set_unit_price(-newDiscountTotal);
-                                console.log(`✅ Precio ajustado: -${newDiscountTotal} por ${allowedRewardQty} unidad(es)`);
-                            } else {
-                                lastRewardLine.set_unit_price(0);
-                                console.log(`⛔ Descuento eliminado porque no se cumple la cantidad mínima`);
-                            }
+                        if (!validLines.length) {
+                            console.log("⛔ No hay productos válidos en el pedido. No se actualiza rewardLine.");
+                            return; // 👈 Salimos sin tocar la línea de recompensa
+                        }
+
+                        const appliedQty = validLines.reduce((sum, l) => sum + l.quantity, 0);
+                        const minQty = program.rule_min_quantity;
+                        const groups = Math.floor(appliedQty / minQty);
+                        const allowedRewardQty = groups * (program.reward_product_quantity || 1);
+
+                        if (allowedRewardQty >= 1) {
+                            const discountPerUnit = validLines[0].product.lst_price * (program.discount_percentage / 100);
+                            const newDiscountTotal = allowedRewardQty * discountPerUnit;
+                            lastRewardLine.set_unit_price(-newDiscountTotal);
+                            console.log(`✅ Precio ajustado: -${newDiscountTotal} por ${allowedRewardQty} unidad(es)`);
+                        } else {
+                            lastRewardLine.set_unit_price(0);
+                            console.log(`⛔ Descuento eliminado porque no se cumple la cantidad mínima`);
                         }
                     }
                 }, 0);
+
             }
 
             return res;
@@ -53,3 +65,4 @@ odoo.define('l10n_mx_quemen.OrderExtension', function(require) {
 
     return models.Order;
 });
+


### PR DESCRIPTION
Se heredó correctamente la función set_quantity en POS para aplicar una lógica personalizada de descuentos por cantidad, relacionada con los programas de cupones.

✅ Se ajusta dinámicamente el precio de la línea de recompensa.

🔄 Se evita que Odoo aplique descuentos por defecto si el producto no participa en la promoción.

⏱️ Se usó setTimeout para asegurar que las líneas ya existan antes de modificar la recompensa.

Este cambio mejora la precisión del comportamiento promocional en el Punto de Venta. 🧾🎯